### PR TITLE
It is better to use the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "GPL-3.0-or-later"
 authors = ["Qingyu Chen <chen_qingyu@qq.com>"]
 description = "My simple matrix library that can perform fraction operations."
 readme = "readme.md"
-homepage = "https://github.com/chen-qingyu/mymatrix"
+repository = "https://github.com/chen-qingyu/mymatrix"
 keywords = ["matrix", "fraction"]
 
 [dependencies]


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See also [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field).